### PR TITLE
Make default video size larger

### DIFF
--- a/behave_html_formatter/html.py
+++ b/behave_html_formatter/html.py
@@ -477,7 +477,7 @@ class HTMLFormatter(Formatter):
                 {
                     "id": "embed_%s" % self.embed_id,
                     "style": "display: none",
-                    "width": "320",
+                    "width": "1024",
                     "controls": "",
                 },
             )


### PR DESCRIPTION
This is to prevent a unreadable small video. Video are attached with size 320, which has to be made full screen to be watchable. This change makes the initial size of video 1024 which can be watched and does not have to be maximized. 