### PR TITLE
Update pipeline implementation after renaming default branch

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,10 +3,10 @@ name: Checks
 on:
   pull_request:
     branches:
-    - master
+    - main
   push:
     branches:
-    - master
+    - main
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,10 +3,10 @@ name: Tests
 on:
   pull_request:
     branches:
-    - master
+    - main
   push:
     branches:
-    - master
+    - main
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,10 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - '2.7'
         - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'
-        - pypy2
         - pypy3
     steps:
     - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 envlist =
     flake8
     pylint
-    py{27,36,37,38,39,py2,py3}
+    py{36,37,38,39,py3}
     readme
     clean
 
@@ -47,12 +47,10 @@ commands =
 
 [gh-actions]
 python =
-    2.7: py27
     3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
-    pypy2: pypy2
     pypy3: pypy3
 
 [behave.formatters]
@@ -71,5 +69,4 @@ output-format = colorized
 [pytest]
 addopts =
     --color=yes
-    --strict
     --verbose


### PR DESCRIPTION
This makes the pipeline jobs run again after renaming the default branch (`master` ➜ `main`).