### PR TITLE
Continue to support Python 3.6, run tests against 3.10 and 3.11

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         env:
+        - black
         - flake8
+        - isort
         - pylint
         - readme
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,6 +21,7 @@ jobs:
         - black
         - flake8
         - isort
+        - minify
         - pylint
         - readme
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ env:
   PY_COLORS: "1"
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,8 +24,8 @@ jobs:
         - pylint
         - readme
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install build tools

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+env:
+  PY_COLORS: "1"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -5,6 +5,9 @@ on:
     tags:
     - "*"
 
+env:
+  PY_COLORS: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -12,8 +12,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install build tools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ env:
   PY_COLORS: "1"
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - main
 
+env:
+  PY_COLORS: "1"
+
 jobs:
   build:
     runs-on: ${{ matrix.platform }}
@@ -26,8 +29,8 @@ jobs:
         - '3.11'
         - 'pypy-3.9'
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install build tools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - ubuntu-latest
+        - ubuntu-20.04
         - macos-latest
         - windows-latest
         python-version:
+        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,11 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'
+        - '3.10'
+        - '3.11'
         - 'pypy-3.9'
     steps:
     - uses: actions/checkout@v2

--- a/behave_html_formatter/html.py
+++ b/behave_html_formatter/html.py
@@ -28,18 +28,15 @@ TODO:
   * Even empty embed elements are contained ?!?
 """
 
+import re
 import xml.etree.ElementTree as ET
-
 from collections import Counter
 from os.path import abspath
 from pathlib import Path
 from sys import version
-
 from xml.dom import minidom
-import re
 
 import six
-
 from behave.formatter.base import Formatter
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+color = true
+
+[tool.isort]
+color_output = true
+profile = "black"
+
+[tool.pylint.master]
+disable = ["attribute-defined-outside-init","invalid-name","W0511","R0903","R0902"]
+output-format = "colorized"

--- a/tests/acceptance/steps/behave4cmd0/command_steps.py
+++ b/tests/acceptance/steps/behave4cmd0/command_steps.py
@@ -11,13 +11,12 @@ import difflib
 import os
 import shutil
 
+from behave import given, matchers, step, then, when
 from hamcrest import assert_that, equal_to, is_not  # UNUSED: contains_string
-from behave import given, when, then, step, matchers
 
 from . import command_shell, command_util, pathutil, textutil
-from .command_shell_proc import TextProcessor, BehaveWinCommandOutputProcessor
+from .command_shell_proc import BehaveWinCommandOutputProcessor, TextProcessor
 from .pathutil import posixpath_normpath
-
 
 matchers.register_type(int=int)
 DEBUG = False

--- a/tests/acceptance/steps/behave4cmd0/command_util.py
+++ b/tests/acceptance/steps/behave4cmd0/command_util.py
@@ -3,11 +3,10 @@ Provides some command utility functions.
 """
 
 import os.path
-import sys
 import shutil
-import time
+import sys
 import tempfile
-
+import time
 from fnmatch import fnmatch
 
 from . import pathutil

--- a/tests/acceptance/steps/behave4cmd0/log/steps.py
+++ b/tests/acceptance/steps/behave4cmd0/log/steps.py
@@ -5,11 +5,11 @@ Provides step definitions to perform tests with the Python logging subsystem.
 import logging
 
 from behave import step, then
-from behave.configuration import LogLevel
 from behave4cmd0.command_steps import (
     step_file_should_contain_multiline_text,
     step_file_should_not_contain_multiline_text,
 )
+from behave.configuration import LogLevel
 
 
 def make_log_record(category, level, message):

--- a/tests/acceptance/steps/behave4cmd0/pathutil.py
+++ b/tests/acceptance/steps/behave4cmd0/pathutil.py
@@ -2,9 +2,9 @@
 Provides some command utility functions.
 """
 
+import codecs
 import os.path
 import sys
-import codecs
 
 
 def realpath_with_context(path, context):

--- a/tests/acceptance/steps/behave4cmd0/textutil.py
+++ b/tests/acceptance/steps/behave4cmd0/textutil.py
@@ -4,7 +4,7 @@ Provides some command utility functions.
 
 import codecs
 
-from hamcrest import assert_that, is_not, equal_to, contains_string
+from hamcrest import assert_that, contains_string, equal_to, is_not
 from hamcrest.core.helpers.hasmethod import hasmethod
 from hamcrest.library.text.substringmatcher import SubstringMatcher
 

--- a/tests/acceptance/steps/use_steplib_behave4cmd.py
+++ b/tests/acceptance/steps/use_steplib_behave4cmd.py
@@ -3,6 +3,6 @@ Use behave4cmd0 step library (predecessor of behave4cmd).
 """
 
 from behave4cmd0 import __all_steps__  # noqa
-from behave4cmd0 import passing_steps  # noqa
 from behave4cmd0 import failing_steps  # noqa
 from behave4cmd0 import note_steps  # noqa
+from behave4cmd0 import passing_steps  # noqa

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,20 @@
 envlist =
     flake8
     pylint
-    py{36,37,38,39,py39}
+    py3{7,8,9,10,11}
+    pypy3
     minify
     readme
     clean
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    pypy-3.9: pypy3
 
 [testenv]
 description = Tests
@@ -31,6 +41,17 @@ commands =
 whitelist_externals =
     rm
 
+[testenv:flake8]
+description = Static code analysis and code style
+deps = flake8-black
+commands = flake8 {posargs}
+
+[testenv:isort]
+description = Ensure imports are ordered consistently
+skip_install = true
+deps = isort[colors]
+commands = isort {posargs:--check-only --diff behave_html_formatter setup.py tests}
+
 [testenv:minify]
 description = Minify CSS and JavaScript code
 deps = css-html-js-minify
@@ -38,30 +59,19 @@ commands =
     css-html-js-minify behave_html_formatter/behave.css
     css-html-js-minify behave_html_formatter/behave.js
 
-[testenv:flake8]
-description = Static code analysis and code style
-deps = flake8-black
-commands = flake8 {posargs}
-
 [testenv:pylint]
 description = Check for errors and code smells
 deps = pylint
-commands = pylint --rcfile tox.ini {posargs:behave_html_formatter setup}
+commands = pylint {posargs:behave_html_formatter setup}
 
 [testenv:readme]
 description = Ensure README renders on PyPI
-deps = twine
+deps =
+    build
+    twine
 commands =
-    {envpython} setup.py -q sdist bdist_wheel
+    python -m build
     twine check dist/*
-
-[gh-actions]
-python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    pypy-3.9: pypy39
 
 [behave]
 paths = tests/acceptance
@@ -71,11 +81,7 @@ html = behave_html_formatter:HTMLFormatter
 
 [flake8]
 exclude = .tox,build,dist,behave_html_formatter.egg-info
-extend-ignore = E203  # see https://github.com/PyCQA/pycodestyle/issues/373
+# see https://github.com/PyCQA/pycodestyle/issues/373
+extend-ignore = E203
 per-file-ignores = ./behave_html_formatter/__init__.py:F401
 max-line-length = 88
-
-[pylint]
-[MASTER]
-disable = attribute-defined-outside-init,invalid-name,W0511,R0903,R0902
-output-format = colorized

--- a/tox.ini
+++ b/tox.ini
@@ -32,11 +32,13 @@ commands = behave {posargs}
 
 [testenv:black]
 description = Ensure consistent code style
+skip_install = true
 deps = black
 commands = black {posargs:--check --diff behave_html_formatter setup.py tests}
 
 [testenv:clean]
 description = Clean up bytecode and build artifacts
+skip_install = true
 deps = pyclean
 commands =
     pyclean {toxinidir}
@@ -46,6 +48,7 @@ whitelist_externals =
 
 [testenv:flake8]
 description = Static code analysis and code style
+skip_install = true
 deps = flake8-black
 commands = flake8 {posargs}
 
@@ -61,6 +64,9 @@ deps = css-html-js-minify
 commands =
     css-html-js-minify behave_html_formatter/behave.css
     css-html-js-minify behave_html_formatter/behave.js
+    git diff --color --exit-code behave_html_formatter/behave.css behave_html_formatter/behave.js
+allowlist_externals =
+    git
 
 [testenv:pylint]
 description = Check for errors and code smells
@@ -69,6 +75,7 @@ commands = pylint {posargs:behave_html_formatter setup}
 
 [testenv:readme]
 description = Ensure README renders on PyPI
+skip_install = true
 deps =
     build
     twine

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
-# tox (https://tox.readthedocs.io/) is a tool for running tests
+# tox (https://tox.wiki/) is a tool for running tests
 # Run tests in multiple virtualenvs.
 
 [tox]
 envlist =
+    black
     flake8
+    isort
     pylint
     py3{7,8,9,10,11}
     pypy3
@@ -28,9 +30,9 @@ deps =
 commands = behave {posargs}
 
 [testenv:black]
-description = Autoformat your Python code
+description = Ensure consistent code style
 deps = black
-commands = black {posargs:behave_html_formatter setup.py tests}
+commands = black {posargs:--check --diff behave_html_formatter setup.py tests}
 
 [testenv:clean]
 description = Clean up bytecode and build artifacts

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     flake8
     isort
     pylint
-    py3{7,8,9,10,11}
+    py3{6,7,8,9,10,11}
     pypy3
     minify
     readme
@@ -15,6 +15,7 @@ envlist =
 
 [gh-actions]
 python =
+    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
GitHub's Azure-based infrastructure offers only newer, officially supported Python versions on the current LTS release (ubuntu-latest).

For a list of supported OS + Python combinations see:
- https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
- https://github.com/actions/runner-images

While we're at making changes, we modernize the setup by moving tool configuration to `pyproject.toml` and by activating color output of Python tools on GHA. We also add Black and isort to make the pipeline setup more complete.

Related: https://github.com/behave-contrib/behave-html-pretty-formatter/issues/4