### PR TITLE
Fixed the report summary error when using scenario outline/examples in a feature file

### DIFF
--- a/behave_html_formatter/html.py
+++ b/behave_html_formatter/html.py
@@ -38,6 +38,7 @@ from xml.dom import minidom
 
 import six
 from behave.formatter.base import Formatter
+from behave.model import ScenarioOutline
 
 
 def _valid_XML_char_ordinal(i):
@@ -496,7 +497,13 @@ class HTMLFormatter(Formatter):
         scenarios_list = [x.scenarios for x in self.all_features]
         scenarios = []
         if len(scenarios_list) > 0:
-            scenarios = [x for subl in scenarios_list for x in subl]
+            for subl in scenarios_list:
+                for x in subl:
+                    if type(x) is ScenarioOutline:
+                        for s in x.scenarios:
+                            scenarios.append(s)
+                    else:
+                        scenarios.append(x)
         statuses = [x.status.name for x in scenarios]
         status_counter = Counter(statuses)
         for k in status_counter:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read_file(filename):
 
 setup(
     name="behave-html-formatter",
-    version="0.9.10",
+    version="0.9.11",
     author="Petr Schindler",
     author_email="pschindl@redhat.com",
     description="HTML formatter for Behave",


### PR DESCRIPTION
When using scenario outlines/examples in a feature file, it is necessary to verify the child scenarios generated by these outlines/examples during the creation of the report summary. For reference, see the previously reported bug https://github.com/behave-contrib/behave-html-formatter/issues/38
